### PR TITLE
Support circular structures

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,13 @@
     "strip-ansi": "^6.0.1"
   },
   "dependencies": {
+    "json-stringify-safe": "^5.0.1",
     "passes": "^1.0.0"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/jest": "29.0.0",
+    "@types/json-stringify-safe": "^5",
     "@types/node": "^18.11.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",

--- a/src/services/strings.spec.ts
+++ b/src/services/strings.spec.ts
@@ -12,4 +12,13 @@ describe("serialize", () => {
     expect(serialize([1, 2, 3])).toBe("[1, 2, 3]");
     expect(serialize({ a: 1, b: 2 })).toBe('{"a": 1, "b": 2}');
   });
+
+  it("handles circular structures", () => {
+    const circular: Record<string, unknown> = {
+      a: 1,
+    };
+
+    circular.b = circular;
+    expect(serialize(circular)).toBe('{"a": 1, "b": "[Circular ~]"}');
+  });
 });

--- a/src/services/strings.ts
+++ b/src/services/strings.ts
@@ -1,3 +1,5 @@
+import stringify from "json-stringify-safe";
+
 /**
  * Serialize an object preserving literal values
  *
@@ -9,7 +11,7 @@
  * @param input - The object to serialize
  */
 export const serialize = (input: unknown): string =>
-  JSON.stringify(input, (_, token: unknown) => {
+  stringify(input, (_, token: unknown) => {
     if (token === undefined) {
       return "undefined";
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-stringify-safe@npm:^5":
+  version: 5.0.3
+  resolution: "@types/json-stringify-safe@npm:5.0.3"
+  checksum: 10c0/5c94cb5476aca6b3dc97f67b581f1bb10c3941bdb8bec652eb836c5f1682b3c25d640a7f73f3829bfecc48358ca05a447f4884936ee1ee3ad6f97944d1cac7ad
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^4.0.0":
   version: 4.0.4
   resolution: "@types/mdast@npm:4.0.4"
@@ -4081,6 +4088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 10c0/7dbf35cd0411d1d648dceb6d59ce5857ec939e52e4afc37601aa3da611f0987d5cee5b38d58329ceddf3ed48bd7215229c8d52059ab01f2444a338bf24ed0f37
+  languageName: node
+  linkType: hard
+
 "json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -5174,6 +5188,7 @@ __metadata:
   dependencies:
     "@types/glob": "npm:^8.1.0"
     "@types/jest": "npm:29.0.0"
+    "@types/json-stringify-safe": "npm:^5"
     "@types/node": "npm:^18.11.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.20.0"
     "@typescript-eslint/parser": "npm:^6.20.0"
@@ -5184,6 +5199,7 @@ __metadata:
     glob: "npm:^11.0.0"
     husky: "npm:^9.0.0"
     jest: "npm:^29.0.0"
+    json-stringify-safe: "npm:^5.0.1"
     passes: "npm:^1.0.0"
     pinst: "npm:^3.0.0"
     prettier: "npm:^3.0.0"


### PR DESCRIPTION
Errors can contain circular structures, this breaks the error output serializer:

```ts
const circular = { a: 1 };
circular.b = circular;
serialize(circular)
```

```shell
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'b' closes the circle
    at JSON.stringify (<anonymous>)
```

Replacing `JSON.stringify` with `json-stringify-safe` fixes this.